### PR TITLE
REF_NOT_FOUND when using page links with namespaces

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,18 +1,18 @@
-import "@logseq/libs";
-import {
-  PageEntity,
-  BlockEntity,
-  SettingSchemaDesc,
-} from "@logseq/libs/dist/LSPlugin";
-import JSZip, { file } from "jszip";
-import { saveAs } from "file-saver";
+import '@logseq/libs';
+
+import { saveAs } from 'file-saver';
+import JSZip, { file } from 'jszip';
+import { title } from 'process';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { BlockEntity, PageEntity, SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin';
+
+import App from './App';
+import { handleClosePopup } from './handleClosePopup';
+import { linkFormats, path } from './index';
+
 export var blocks2 = [];
-import React from "react";
-import ReactDOM from "react-dom";
-import App from "./App";
-import { handleClosePopup } from "./handleClosePopup";
-import { linkFormats, path } from "./index";
-import { title } from "process";
 var errorTracker = [];
 var zip = new JSZip();
 var imageTracker = [];
@@ -314,7 +314,7 @@ function parseLinks(text: string, allPublicPages) {
   let result
   while(result = (reDescrLink.exec(text) || reLink.exec(text))) {
     if (allPublicLinks.includes(result[result.length - 1].toLowerCase())) {
-      text = text.replace(result[0],`[${result[1]}]({{< ref "${result[result.length - 1]}" >}})`)
+      text = text.replace(result[0],`[${result[1]}]({{< ref "/pages/${result[result.length - 1]}" >}})`)
     }
   } 
     if (logseq.settings.linkFormat == "Without brackets") {


### PR DESCRIPTION
Problem:
Data in Logseq:
test 1/page 1 -> has link to page 2 [[test 2/page 2]]
test 2/page 2 -> has link to page 1 [[test 1/page 1]]

Export with the plugin to Markdown:
content/pages/test 1/page 1.md -> link to {{< ref "test 2/page 2" >}} -> not working!
content/pages/test 2/page 2.md -> link to {{< ref "test 1/page 1" >}} -> not working! 

Solution:
Add /page/ before each page link;
{{< ref "/page/test 2/page 2" >}