### PR TITLE
Multiline Adminitions not converted correctly on export

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,18 +1,18 @@
-import "@logseq/libs";
-import {
-  PageEntity,
-  BlockEntity,
-  SettingSchemaDesc,
-} from "@logseq/libs/dist/LSPlugin";
-import JSZip, { file } from "jszip";
-import { saveAs } from "file-saver";
+import '@logseq/libs';
+
+import { saveAs } from 'file-saver';
+import JSZip, { file } from 'jszip';
+import { title } from 'process';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { BlockEntity, PageEntity, SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin';
+
+import App from './App';
+import { handleClosePopup } from './handleClosePopup';
+import { linkFormats, path } from './index';
+
 export var blocks2 = [];
-import React from "react";
-import ReactDOM from "react-dom";
-import App from "./App";
-import { handleClosePopup } from "./handleClosePopup";
-import { linkFormats, path } from "./index";
-import { title } from "process";
 var errorTracker = [];
 var zip = new JSZip();
 var imageTracker = [];
@@ -314,7 +314,7 @@ function parseLinks(text: string, allPublicPages) {
   let result
   while(result = (reDescrLink.exec(text) || reLink.exec(text))) {
     if (allPublicLinks.includes(result[result.length - 1].toLowerCase())) {
-      text = text.replace(result[0],`[${result[1]}]({{< ref "${result[result.length - 1]}" >}})`)
+      text = text.replace(result[0],`[${result[1]}]({{< ref "/pages/${result[result.length - 1]}" >}})`)
     }
   } 
     if (logseq.settings.linkFormat == "Without brackets") {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -420,7 +420,7 @@ async function parseText(block: BlockEntity) {
   re = /(==(.*?)==)/gm;
   text = text.replace(re, "{{< logseq/mark >}}$2{{< / logseq/mark >}}");
 
-  re = /#\+BEGIN_([A-Z]*).*\n(.*)\n#\+END_.*/gm;
+  re = /#\+BEGIN_([A-Z]*)[^\n]*\n(.*)#\+END_[^\n]*/gms;
   text = text.replace(re, "{{< logseq/org$1 >}}$2{{< / logseq/org$1 >}}");
   // text = text.toLowerCase();
 


### PR DESCRIPTION
Problem:
The regex pattern in the export script is only looking for adminitions terminated by a newline character. This does not work if the adminition extends over several lines.

Solution:
Included newlines in the regex, excluded newlines from the pattern where they're not needed and terminated the search pattern by the string #+END_. Hope this works for all cases.