### PR TITLE
feat: convert numbered-list bullets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-schrodinger",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "An awesome logseq plugin to export to Hugo Static sites and jumpstart your digital garden 🌱!",
   "main": "dist/index.html",
   "targets": {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -429,8 +429,20 @@ async function parseText(block: BlockEntity) {
   // Experiment, no more lists, unless + or numbers
   // (unless they're not)
   if (logseq.settings.bulletHandling == "Convert Bullets") {
+    // convert numbered-list bullets
+    if (block.level === 1) {
+      if (text.includes("logseq.order-list-type:: number")) {
+        txtBefore = "1. ";
+        text = text.replace("logseq.order-list-type:: number", "");
+      }
+    }
     if (block.level > 1) {
-      txtBefore = " ".repeat((block.level - 1) * 2) + "+ ";
+      if (text.includes("logseq.order-list-type:: number")) {
+        txtBefore = " ".repeat((block.level - 1) * 4) + "1. ";
+        text = text.replace("logseq.order-list-type:: number", "");
+      } else {
+        txtBefore = " ".repeat((block.level - 1) * 2) + "+ ";
+      }
       // txtBefore = "\n" + txtBefore
       if (prevBlock.level === block.level) txtAfter = "";
     }


### PR DESCRIPTION
### What happend?
  For example, if I use the number-list type in logseq and input something:

   ![image](https://github.com/sawhney17/logseq-schrodinger/assets/141131070/69f6ff25-1be6-4129-adf3-df44ffed1232)

   ![image](https://github.com/sawhney17/logseq-schrodinger/assets/141131070/5be84ab5-3560-447a-a1f8-32daa4ab1509)

  The actual contents in the  `.md` file which is in  the publicExport.zip are:
   ```
  test
  logseq.order-list-type:: number

  hello world
  logseq.order-list-type:: number

    + hi
  logseq.order-list-type:: number

    + hey
  logseq.order-list-type:: number

      + yes
  logseq.order-list-type:: number

      + no
  logseq.order-list-type:: number

    + goodbye
  logseq.order-list-type:: number

  bye
  logseq.order-list-type:: number

  hello

  not bad
  logseq.order-list-type:: number

  good
  logseq.order-list-type:: number
  ```
👆 The list numberings are missing and `logseq.order-list-type:: number` are added to the contents.

### What I Do？
I wrote some codes to remove `logseq.order-list-type:: number` and keep the list numberings.👇

- The actual contents in the .md file which is in the publicExport.zip are:
  ```
  1. test


  1. hello world


      1. hi


      1. hey


          1. yes


          1. no


      1. goodbye


  1. bye


  hello

  1. not bad


  1. good
  ```
- Then we can see this in Hugo:
  ![image](https://github.com/sawhney17/logseq-schrodinger/assets/141131070/c5ddf42c-4ce9-41c6-a18c-9404ef0c5706)
